### PR TITLE
simple facebook social login

### DIFF
--- a/WEB-MAC-HACK-KI/build.gradle
+++ b/WEB-MAC-HACK-KI/build.gradle
@@ -48,10 +48,14 @@ dependencies {
     compile('org.antlr:ST4:4.0.8')
     compile ('org.apache.tiles:tiles-extras:3.0.7')
     compile('org.webjars.npm:handlebars:4.0.6')
-    compile('org.springframework.social:spring-social-facebook')
-    compile group: 'org.springframework.boot', name: 'spring-boot-devtools', version: '1.5.8.RELEASE'
+    compile('org.springframework.boot:spring-boot-devtools:1.5.8.RELEASE')
 
     compile('org.springframework.security:spring-security-config:4.2.3.RELEASE')
+    compile('org.springframework.boot:spring-boot-starter-security:1.5.9.RELEASE')
+    compile('org.springframework.security.oauth:spring-security-oauth2:2.2.1.RELEASE')
+
+    compile('org.webjars.bower:jquery:3.2.1')
+    compile('org.webjars:bootstrap:3.3.7-1')
 
     runtime('com.h2database:h2')
     runtime('mysql:mysql-connector-java')

--- a/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/MachackkiApplication.java
+++ b/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/MachackkiApplication.java
@@ -14,7 +14,6 @@ import java.security.Principal;
 @SpringBootApplication
 @EnableAsync
 @EnableJpaAuditing
-@EnableOAuth2Sso
 @EntityScan(basePackageClasses = {Jsr310JpaConverters.class},  // basePackageClasses에 지정
 		basePackages = {"com.amigotrip.domain"})
 public class MachackkiApplication {

--- a/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/MachackkiApplication.java
+++ b/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/MachackkiApplication.java
@@ -3,16 +3,22 @@ package com.amigotrip;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
 import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.security.Principal;
 
 @SpringBootApplication
 @EnableAsync
 @EnableJpaAuditing
+@EnableOAuth2Sso
 @EntityScan(basePackageClasses = {Jsr310JpaConverters.class},  // basePackageClasses에 지정
 		basePackages = {"com.amigotrip.domain"})
 public class MachackkiApplication {
+
 	public static void main(String[] args) {
 		SpringApplication.run(MachackkiApplication.class, args);
 	}

--- a/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/AuthController.java
+++ b/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/AuthController.java
@@ -1,0 +1,17 @@
+package com.amigotrip.web;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+/**
+ * Created by Woohyeon on 2018. 1. 9..
+ */
+@RestController
+public class AuthController {
+    @RequestMapping("/user")
+    public Principal user(Principal principal) {
+        return principal;
+    }
+}

--- a/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/AuthController.java
+++ b/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/AuthController.java
@@ -1,5 +1,7 @@
 package com.amigotrip.web;
 
+import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,7 +12,7 @@ import java.security.Principal;
  */
 @RestController
 public class AuthController {
-    @RequestMapping("/user")
+    @GetMapping("/user")
     public Principal user(Principal principal) {
         return principal;
     }

--- a/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/HomeController.java
+++ b/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/HomeController.java
@@ -10,8 +10,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.social.connect.ConnectionRepository;
-import org.springframework.social.facebook.api.Facebook;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,7 +17,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import javax.annotation.Resource;
-import javax.inject.Inject;
 import javax.servlet.http.HttpSession;
 import java.security.Principal;
 import java.util.List;
@@ -37,19 +34,8 @@ public class HomeController {
     @Resource
     private ArticleService articleService;
 
-    private Facebook facebook;
-    private ConnectionRepository connectionRepository;
-
-    public HomeController(Facebook facebook, ConnectionRepository connectionRepository) {
-        this.facebook = facebook;
-        this.connectionRepository = connectionRepository;
-    }
-
     @GetMapping("/")
     public String main(Authentication principal, HttpSession session, Model model) {
-        if(connectionRepository.findPrimaryConnection(Facebook.class) != null) {
-            log.debug("{}", facebook.userOperations().getUserProfile());
-        }
         SecurityContext securityContext = SecurityContextHolder.getContext();
 
         if (principal != null) {
@@ -74,7 +60,7 @@ public class HomeController {
 
     @GetMapping("/test")
     public String test() {
-        return "editProfile";
+        return "authTest";
     }
 }
 

--- a/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/config/WebSecurityConfig.java
+++ b/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/config/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.amigotrip.web.config;
 
 import com.amigotrip.service.CustomUserDetailsService;
+import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +22,7 @@ import javax.annotation.Resource;
  */
 @Configuration
 @EnableWebSecurity
+@EnableOAuth2Sso
 @ComponentScan("com.amigotrip.service")
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
@@ -31,12 +33,13 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http
                 .antMatcher("/**")
                 .authorizeRequests()
-                    .antMatchers("/", "/login**", "/webjars/**")
+                    .antMatchers("/", "/test", "/login**", "/webjars/**")
                     .permitAll()
+                .anyRequest().authenticated()
                 .and()
                 .logout()
                     .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
-                    .logoutSuccessUrl("/");
+                    .logoutSuccessUrl("/test"); // for facebook social login test only
     }
 
     @Bean

--- a/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/config/WebSecurityConfig.java
+++ b/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/config/WebSecurityConfig.java
@@ -29,12 +29,15 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http.headers().frameOptions().disable();
 
         http
+                .antMatcher("/**")
+                .authorizeRequests()
+                    .antMatchers("/", "/login**", "/webjars/**")
+                    .permitAll()
+                .and()
                 .logout()
                     .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
                     .logoutSuccessUrl("/");
     }
-
-
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {

--- a/WEB-MAC-HACK-KI/src/main/resources/application.properties
+++ b/WEB-MAC-HACK-KI/src/main/resources/application.properties
@@ -24,5 +24,11 @@ userPhotoUpload.path=/Users/Naver/amigo-userphoto/
 spring.http.multipart.max-file-size=10MB
 spring.http.multipart.max-request-size=10MB
 
-spring.social.facebook.appId=1589290074448285
-spring.social.facebook.appSecret=863ce25661b1ca48812afb4ac1c94043
+security.oauth2.client.clientId = 1589290074448285
+security.oauth2.client.clientSecret = 863ce25661b1ca48812afb4ac1c94043
+security.oauth2.client.accessTokenUri = https://graph.facebook.com/oauth/access_token
+security.oauth2.client.userAuthorizationUri = https://www.facebook.com/dialog/oauth
+security.oauth2.client.tokenName = oauth_token
+security.oauth2.client.authenticationScheme = query
+security.oauth2.client.clientAuthenticationScheme = form
+security.oauth2.resource.userInfoUri = https://graph.facebook.com/me

--- a/WEB-MAC-HACK-KI/src/main/resources/templates/authTest.html
+++ b/WEB-MAC-HACK-KI/src/main/resources/templates/authTest.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8"/>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <title>Demo</title>
+        <meta name="description" content=""/>
+        <meta name="viewport" content="width=device-width"/>
+        <base href="/"/>
+        <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css"/>
+        <script type="text/javascript" src="/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js"></script>
+    </head>
+    <body>
+        <h1>Demo</h1>
+        <div class="container">
+            <div class="container unauthenticated">
+                With Facebook: <a href="/login">click here</a>
+            </div>
+            <div class="container authenticated" style="display:none">
+                Logged in as: <span id="user"></span>
+                <div>
+                    <button onClick="logout()" class="btn btn-primary">Logout</button>
+                </div>
+            </div>
+        </div>
+        <script type="text/javascript" src="/webjars/jquery/3.2.1/dist/jquery.min.js"></script>
+        <script type="text/javascript">
+          $.get("/user", function(data) {
+            $("#user").html(data.userAuthentication.details.name);
+            $(".unauthenticated").hide()
+            $(".authenticated").show()
+          });
+
+          var logout = function() {
+            $.post("/logout", function() {
+              $("#user").html('');
+              $(".unauthenticated").show();
+              $(".authenticated").hide();
+            })
+            return true;
+          }
+        </script>
+    </body>
+</html>

--- a/WEB-MAC-HACK-KI/src/main/resources/templates/authTest.html
+++ b/WEB-MAC-HACK-KI/src/main/resources/templates/authTest.html
@@ -8,6 +8,7 @@
         <meta name="viewport" content="width=device-width"/>
         <base href="/"/>
         <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css"/>
+        <script type="text/javascript" src="/webjars/jquery/1.11.1/jquery.js"></script>
         <script type="text/javascript" src="/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js"></script>
     </head>
     <body>
@@ -23,9 +24,10 @@
                 </div>
             </div>
         </div>
-        <script type="text/javascript" src="/webjars/jquery/3.2.1/dist/jquery.min.js"></script>
+        <!--<script type="text/javascript" src="/webjars/jquery/3.2.1/dist/jquery.min.js"></script>-->
         <script type="text/javascript">
           $.get("/user", function(data) {
+            console.log(data);
             $("#user").html(data.userAuthentication.details.name);
             $(".unauthenticated").hide()
             $(".authenticated").show()


### PR DESCRIPTION
## 문제 원인 & 해결
- `@EnableOAuth2Sso` 라는 애너테이션은 `WebSecurityConfigurerAdapter`가 구현된 클래스에 붙었을 때 특별한 의미를 가짐. 스프링 부트가 적절한 위치의 `@EnableOAuth2Sso` 애너테이션을 발견하면 OAuth2 authentication을 과정을 수행하는 processor를 가지고 있는 security filter chain을 설정함. 변경 전에는 `MachackkiApplication.java`에 애너테이션이 붙어있어서 이 설정이 되지 못함
- WebSecurityConfig의 configure 에서 설정하는 부분은 `"/", "/test", "/login**", "/webjars/**"`, 처럼 소셜 로그인을 시도하기 위해 접근이 필요한 페이지와 그 페이지에 사용되는 resource들의 경로를 제외하고는 모든 요청이 authenticated 되었는지 검사하도록 함 (`.anyRequest().authenticated()`)
- jQuery가 제대로 로드 되지 못해 로그인이 성공해도 서버 api 호출을 하지 않고 있었음
- 서버에서 `/user` endpoint가 제대로 매핑 되지 못하고 있었음. `@RequestMapping`을 `@GetMapping`으로 수정
  