### PR TITLE
facebook & github social login with manual filter configuration

### DIFF
--- a/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/config/WebSecurityConfig.java
+++ b/WEB-MAC-HACK-KI/src/main/java/com/amigotrip/web/config/WebSecurityConfig.java
@@ -24,6 +24,7 @@ import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.filter.OAuth2ClientAuthenticationProcessingFilter;
 import org.springframework.security.oauth2.client.filter.OAuth2ClientContextFilter;
 import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeResourceDetails;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -40,61 +41,12 @@ import java.util.List;
  */
 @Configuration
 @EnableWebSecurity
-@EnableOAuth2Sso
+@EnableOAuth2Client
 @ComponentScan("com.amigotrip.service")
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
     @Autowired
-    private OAuth2ClientContext oAuth2ClientContext;
-
-    @Primary
-    @Bean
-    @ConfigurationProperties("facebook.resource")
-    public ResourceServerProperties facebookResource() {
-        return new ResourceServerProperties();
-    }
-
-    @Bean
-    @ConfigurationProperties("facebook")
-    public ClientResources facebook() {
-        return new ClientResources();
-    }
-
-    private Filter ssoFilter(ClientResources client, String path) {
-        OAuth2ClientAuthenticationProcessingFilter filter = new OAuth2ClientAuthenticationProcessingFilter(path);
-        OAuth2RestTemplate template = new OAuth2RestTemplate(client.getClient(), oAuth2ClientContext);
-        filter.setRestTemplate(template);
-        UserInfoTokenServices tokenServices = new UserInfoTokenServices(
-                client.getResource().getUserInfoUri(), client.getClient().getClientId());
-        tokenServices.setRestTemplate(template);
-        filter.setTokenServices(tokenServices);
-        return filter;
-    }
-
-    private Filter ssoFilter() {
-        CompositeFilter filter = new CompositeFilter();
-        List<Filter> filters = new ArrayList<>();
-        filters.add(ssoFilter(facebook(), "/login/facebook"));
-
-//        OAuth2ClientAuthenticationProcessingFilter facebookFilter = new OAuth2ClientAuthenticationProcessingFilter("/login/facebook");
-//        OAuth2RestTemplate facebookTemplate = new OAuth2RestTemplate(facebook(), oAuth2ClientContext);
-//        facebookFilter.setRestTemplate(facebookTemplate);
-//        UserInfoTokenServices tokenServices = new UserInfoTokenServices(facebookResource().getUserInfoUri(), facebook().getClientId());
-//        tokenServices.setRestTemplate(facebookTemplate);
-//        facebookFilter.setTokenServices(tokenServices);
-//        filters.add(facebookFilter);
-
-        filter.setFilters(filters);
-        return filter;
-    }
-
-    @Bean
-    public FilterRegistrationBean oauth2ClientFilterRegistration(
-            OAuth2ClientContextFilter filter) {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        registration.setFilter(filter);
-        registration.setOrder(-100);
-        return registration;
-    }
+    OAuth2ClientContext oAuth2ClientContext;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -111,6 +63,37 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .logout()
                     .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
                     .logoutSuccessUrl("/");
+    }
+
+    private Filter ssoFilter() {
+        OAuth2ClientAuthenticationProcessingFilter facebookFilter = new OAuth2ClientAuthenticationProcessingFilter("/login/facebook");
+        OAuth2RestTemplate facebookTemplate = new OAuth2RestTemplate(facebook(), oAuth2ClientContext);
+        facebookFilter.setRestTemplate(facebookTemplate);
+        UserInfoTokenServices tokenServices = new UserInfoTokenServices(facebookResource().getUserInfoUri(), facebook().getClientId());
+        tokenServices.setRestTemplate(facebookTemplate);
+        facebookFilter.setTokenServices(tokenServices);
+        return facebookFilter;
+    }
+
+    @Bean
+    public FilterRegistrationBean oauth2ClientFilterRegistration(
+            OAuth2ClientContextFilter filter) {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(filter);
+        registration.setOrder(-100);
+        return registration;
+    }
+
+    @Bean
+    @ConfigurationProperties("facebook.client")
+    public AuthorizationCodeResourceDetails facebook() {
+        return new AuthorizationCodeResourceDetails();
+    }
+
+    @Bean
+    @ConfigurationProperties("facebook.resource")
+    public ResourceServerProperties facebookResource() {
+        return new ResourceServerProperties();
     }
 
     @Bean

--- a/WEB-MAC-HACK-KI/src/main/resources/application.properties
+++ b/WEB-MAC-HACK-KI/src/main/resources/application.properties
@@ -24,11 +24,20 @@ userPhotoUpload.path=/Users/Naver/amigo-userphoto/
 spring.http.multipart.max-file-size=10MB
 spring.http.multipart.max-request-size=10MB
 
-security.oauth2.client.clientId = 1589290074448285
-security.oauth2.client.clientSecret = 863ce25661b1ca48812afb4ac1c94043
-security.oauth2.client.accessTokenUri = https://graph.facebook.com/oauth/access_token
-security.oauth2.client.userAuthorizationUri = https://www.facebook.com/dialog/oauth
-security.oauth2.client.tokenName = oauth_token
-security.oauth2.client.authenticationScheme = query
-security.oauth2.client.clientAuthenticationScheme = form
-security.oauth2.resource.userInfoUri = https://graph.facebook.com/me?fields=id,name,email,birthday,location,picture
+#security.oauth2.client.clientId = 1589290074448285
+#security.oauth2.client.clientSecret = 863ce25661b1ca48812afb4ac1c94043
+#security.oauth2.client.accessTokenUri = https://graph.facebook.com/oauth/access_token
+#security.oauth2.client.userAuthorizationUri = https://www.facebook.com/dialog/oauth
+#security.oauth2.client.tokenName = oauth_token
+#security.oauth2.client.authenticationScheme = query
+#security.oauth2.client.clientAuthenticationScheme = form
+#security.oauth2.resource.userInfoUri = https://graph.facebook.com/me?fields=id,name,email,birthday,location,picture
+
+facebook.client.clientId = 1589290074448285
+facebook.client.clientSecret = 863ce25661b1ca48812afb4ac1c94043
+facebook.client.accessTokenUri = https://graph.facebook.com/oauth/access_token
+facebook.client.userAuthorizationUri = https://www.facebook.com/dialog/oauth
+facebook.client.tokenName = oauth_token
+facebook.client.authenticationScheme = query
+facebook.client.clientAuthenticationScheme = form
+facebook.resource.userInfoUri = https://graph.facebook.com/me?fields=id,name,email,birthday,location,picture

--- a/WEB-MAC-HACK-KI/src/main/resources/application.properties
+++ b/WEB-MAC-HACK-KI/src/main/resources/application.properties
@@ -41,3 +41,10 @@ facebook.client.tokenName = oauth_token
 facebook.client.authenticationScheme = query
 facebook.client.clientAuthenticationScheme = form
 facebook.resource.userInfoUri = https://graph.facebook.com/me?fields=id,name,email,birthday,location,picture
+
+github.client.clientId = ef05824a45c6ab9d7f20
+github.client.clientSecret = 15539ff7f7e7df42ee5d9a8cd46db23c6194161a
+github.client.accessTokenUri = https://github.com/login/oauth/access_token
+github.client.userAuthorizationUri = https://github.com/login/oauth/authorize
+github.client.clientAuthenticationScheme = form
+github.resource.userInfoUri = https://api.github.com/user

--- a/WEB-MAC-HACK-KI/src/main/resources/templates/authTest.html
+++ b/WEB-MAC-HACK-KI/src/main/resources/templates/authTest.html
@@ -8,13 +8,14 @@
         <meta name="viewport" content="width=device-width"/>
         <base href="/"/>
         <link rel="stylesheet" type="text/css" href="/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css"/>
+        <script type="text/javascript" src="/webjars/jquery/1.11.1/jquery.min.js"></script>
         <script type="text/javascript" src="/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js"></script>
     </head>
     <body>
         <h1>Demo</h1>
         <div class="container">
             <div class="container unauthenticated">
-                With Facebook: <a href="/login">click here</a>
+                With Facebook: <a href="/login/facebook">click here</a>
             </div>
             <div class="container authenticated" style="display:none">
                 Logged in as: <span id="user"></span>

--- a/WEB-MAC-HACK-KI/src/main/resources/templates/authTest.html
+++ b/WEB-MAC-HACK-KI/src/main/resources/templates/authTest.html
@@ -15,7 +15,12 @@
         <h1>Demo</h1>
         <div class="container">
             <div class="container unauthenticated">
-                With Facebook: <a href="/login/facebook">click here</a>
+                <div>
+                    With Facebook: <a href="/login/facebook">click here - facebook</a>
+                </div>
+                <div>
+                    With Github: <a href="/login/github">click here - github</a>
+                </div>
             </div>
             <div class="container authenticated" style="display:none">
                 Logged in as: <span id="user"></span>
@@ -27,6 +32,7 @@
         <script type="text/javascript" src="/webjars/jquery/3.2.1/dist/jquery.min.js"></script>
         <script type="text/javascript">
           $.get("/user", function(data) {
+            console.log(data);
             $("#user").html(data.userAuthentication.details.name);
             $(".unauthenticated").hide()
             $(".authenticated").show()


### PR DESCRIPTION
자잘한 미스가 있었음
`application.properties` 파일에 설정된 정보 이름들을 `security.oauth2` 가 아니라 `facebook` 으로 바꿔줌. github도 새로 설정 추가할 때 `github.~~` 해서 추가함. `@ConfigurationProperties` 애너테이션이 이걸 해주기 위해 있었던 것임. 그 밖엔 `configure()` 에서 `.anyRequest().authenticated()` 요 부분을 빠뜨리고 있었다든지 했음

전체적으로 봤을 때 자료 보고 차근 차근 안 따라가고 듬성듬성 따라간 것 같이 보이는 데 이게 어찌된 일이요
개발자양반